### PR TITLE
Minor cleanup and adjustments.

### DIFF
--- a/src/Commands.Samples/Commands.Samples.Console/Program.cs
+++ b/src/Commands.Samples/Commands.Samples.Console/Program.cs
@@ -13,7 +13,7 @@ var manager = ComponentCollection.With
     .Create();
 
 var testRunner = TestRunner.With
-    .Commands(manager.GetCommands().ToArray())
+    .Commands([.. manager.GetCommands()])
     .Create();
 
 var testEvaluation = await testRunner.Run((str) => new TestContext(str));

--- a/src/Commands.Samples/Commands.Samples.Hosting/Program.cs
+++ b/src/Commands.Samples/Commands.Samples.Hosting/Program.cs
@@ -10,7 +10,7 @@ await Host.CreateDefaultBuilder(args)
     {
         // We configure a configuration for our components. Most of the time, we do this to define custom parsers.
         // TypeParser implementations allow command arguments to be parsed into the expected format and type.
-        services.AddSingleton<ComponentConfiguration>((services) =>
+        services.AddSingleton((services) =>
         {
             var config = new ComponentConfiguration();
 
@@ -21,7 +21,7 @@ await Host.CreateDefaultBuilder(args)
 
         // We configure a component manager to manage our components.
         // This manager requires a configuration and a set of handlers to process the results of command execution.
-        services.AddSingleton<ComponentCollection>((services) =>
+        services.AddSingleton((services) =>
         {
             var config = services.GetRequiredService<ComponentConfiguration>();
             var logger = services.GetRequiredService<ILogger<Program>>();

--- a/src/Commands/Conditions/ExecuteCondition.cs
+++ b/src/Commands/Conditions/ExecuteCondition.cs
@@ -1,6 +1,5 @@
 ﻿namespace Commands.Conditions;
 
-
 /// <summary>
 ///     A delegate-based condition that determines whether a command can execute or not.
 /// </summary>

--- a/src/Commands/Core/Components/Abstractions/IComponent.cs
+++ b/src/Commands/Core/Components/Abstractions/IComponent.cs
@@ -1,5 +1,4 @@
-﻿using Commands.Conditions;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace Commands;
 

--- a/src/Commands/Core/Components/Activators/CommandModuleActivator.cs
+++ b/src/Commands/Core/Components/Activators/CommandModuleActivator.cs
@@ -28,7 +28,7 @@ internal readonly struct CommandModuleActivator : IDependencyActivator<CommandMo
 
         Type = type;
     }
-    
+
     public CommandModule Activate(IServiceProvider services)
     {
         var obj = services.GetService(Type!);

--- a/src/Commands/Core/Components/Command.cs
+++ b/src/Commands/Core/Components/Command.cs
@@ -113,7 +113,7 @@ public sealed class Command : IComponent, IParameterCollection
     /// <param name="executionMethod">The method to run when the command is executed.</param>
     /// <param name="parent">The parent of this command, if any. Irrespective of this value being set, the command can still be added to groups at any time. This parameter will however, inherit the execution conditions from the parent.</param>
     /// <param name="configuration">An optional configuration containing additional settings when creating this command.</param>
-    public Command(MethodInfo executionMethod, CommandGroup? parent = null, ComponentConfiguration ? configuration = null)
+    public Command(MethodInfo executionMethod, CommandGroup? parent = null, ComponentConfiguration? configuration = null)
         : this(executionMethod.IsStatic ? new CommandStaticActivator(executionMethod) : new CommandInstanceActivator(executionMethod), configuration ?? ComponentConfiguration.Empty)
     {
         Names = Attributes.FirstOrDefault<NameAttribute>()?.Names ?? [];
@@ -134,7 +134,7 @@ public sealed class Command : IComponent, IParameterCollection
         var parameters = ComponentUtilities.GetParameters(activator, configuration);
         var attributes = activator.Target.GetAttributes(true);
 
-        Attributes = attributes.ToArray();
+        Attributes = [.. attributes];
         Activator = activator;
 
         (MinLength, MaxLength) = parameters.GetLength();

--- a/src/Commands/Core/Components/CommandGroup.cs
+++ b/src/Commands/Core/Components/CommandGroup.cs
@@ -71,7 +71,7 @@ public sealed class CommandGroup : ComponentCollectionBase, IComponent
 
         var attributes = type.GetAttributes(true);
 
-        Attributes = attributes.ToArray();
+        Attributes = [.. attributes];
 
         Ignore = attributes.Contains<IgnoreAttribute>();
         Names = attributes.FirstOrDefault<NameAttribute>()?.Names ?? [];

--- a/src/Commands/Core/Components/CommandGroupProperties.cs
+++ b/src/Commands/Core/Components/CommandGroupProperties.cs
@@ -1,5 +1,4 @@
-﻿using Commands.Conditions;
-
+﻿
 namespace Commands;
 
 /// <summary>
@@ -90,7 +89,7 @@ public sealed class CommandGroupProperties : IComponentProperties
         var group = new CommandGroup([.. _names]);
 
         if (_components.Count != 0)
-            group.AddRange(_components.Select(component => component.Create(configuration)).ToArray());
+            group.AddRange([.. _components.Select(component => component.Create(configuration))]);
 
         return group;
     }

--- a/src/Commands/Core/Components/CommandParameter.cs
+++ b/src/Commands/Core/Components/CommandParameter.cs
@@ -1,5 +1,4 @@
 ﻿using Commands.Parsing;
-using System.Xml.Linq;
 
 namespace Commands;
 
@@ -72,7 +71,7 @@ public sealed class CommandParameter : ICommandParameter
         // Assign the parser defined on the parameter if it exists, otherwise use the one defined in the configuration.
         Parser = attributes.FirstOrDefault<ITypeParser>() ?? configuration.GetParser(Type);
 
-        Attributes = attributes.ToArray();
+        Attributes = [.. attributes];
 
         Name = attributes.FirstOrDefault<NameAttribute>()?.Name ?? parameterInfo.Name ?? "";
     }

--- a/src/Commands/Core/Components/ComponentCollection.cs
+++ b/src/Commands/Core/Components/ComponentCollection.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
+﻿
 namespace Commands;
 
 /// <summary>
@@ -34,7 +33,7 @@ public sealed class ComponentCollection : ComponentCollectionBase, IExecutionPro
         Configuration = configuration;
 
         // We choose not to set a standard handler through this constructor, in case it is desired that someone absolutely does not want to use one.
-        _handlers = handlers.ToArray();
+        _handlers = [.. handlers];
     }
 
     /// <summary>
@@ -61,7 +60,7 @@ public sealed class ComponentCollection : ComponentCollectionBase, IExecutionPro
     /// <param name="types">A collection of types to filter and add to the manager, where possible.</param>
     /// <returns>The number of added components; or 0 if no components are added.</returns>
     public int AddRange(IEnumerable<Type> types)
-    { 
+    {
         var components = ComponentUtilities.GetComponents(types, Configuration);
         return AddRange(components);
     }
@@ -142,7 +141,7 @@ public sealed class ComponentCollection : ComponentCollectionBase, IExecutionPro
 
     #region Initializers
 
-        /// <inheritdoc cref="From(IComponentProperties[])"/>
+    /// <inheritdoc cref="From(IComponentProperties[])"/>
     public static ComponentCollectionProperties With
         => new();
 

--- a/src/Commands/Core/Components/ComponentCollectionBase.cs
+++ b/src/Commands/Core/Components/ComponentCollectionBase.cs
@@ -118,7 +118,7 @@ public abstract class ComponentCollectionBase : IComponentCollection
             return additions.Count;
         }
     }
-    
+
     /// <inheritdoc />
     public bool Remove(IComponent component)
         => RemoveRange([component]) > 0;
@@ -142,7 +142,7 @@ public abstract class ComponentCollectionBase : IComponentCollection
             if (mutations > 0)
             {
                 _mutateParent?.Invoke(components, true);
-                _items = [..copy];
+                _items = [.. copy];
             }
 
             return mutations;
@@ -177,7 +177,7 @@ public abstract class ComponentCollectionBase : IComponentCollection
         private IComponent? _current;
 
         /// <inheritdoc />
-        public IComponent Current
+        public readonly IComponent Current
             => _current!;
 
         internal StateEnumerator(ComponentCollectionBase collection)
@@ -213,7 +213,7 @@ public abstract class ComponentCollectionBase : IComponentCollection
         /// <inheritdoc />
         public readonly void Dispose() { }
 
-        object IEnumerator.Current
+        readonly object IEnumerator.Current
             => Current;
     }
 

--- a/src/Commands/Core/Components/ComponentCollectionProperties.cs
+++ b/src/Commands/Core/Components/ComponentCollectionProperties.cs
@@ -184,9 +184,7 @@ public sealed class ComponentCollectionProperties
 
         var configuration = _configuration.Create();
 
-        var handlers = _handlers.Select(handler => handler.Create()).ToArray();
-
-        var manager = new ComponentCollection(configuration, handlers);
+        var manager = new ComponentCollection(configuration, [.. _handlers.Select(handler => handler.Create())]);
 
         manager.AddRange(_components.Select(component => component.Create(configuration: configuration)));
         manager.AddRange(ComponentUtilities.GetComponents(configuration, _dynamicTypes, null, false));

--- a/src/Commands/Core/Components/ComponentUtilities.cs
+++ b/src/Commands/Core/Components/ComponentUtilities.cs
@@ -125,7 +125,7 @@ public static class ComponentUtilities
                 {
                     try
                     {
-                        results[i] = ParseResult.FromSuccess(complexParameter.Activator.Invoke(caller, null, result.Select(x => x.Value).ToArray(), options));
+                        results[i] = ParseResult.FromSuccess(complexParameter.Activator.Invoke(caller, null, [.. result.Select(x => x.Value)], options));
                     }
                     catch (Exception ex)
                     {
@@ -203,7 +203,7 @@ public static class ComponentUtilities
         var parameters = activator.Target.GetParameters();
 
         if (activator.HasContext)
-            parameters = parameters.Skip(1).ToArray();
+            parameters = [.. parameters.Skip(1)];
 
         var arr = new ICommandParameter[parameters.Length];
 

--- a/src/Commands/Core/Components/ConstructibleParameter.cs
+++ b/src/Commands/Core/Components/ConstructibleParameter.cs
@@ -94,7 +94,7 @@ public class ConstructibleParameter : ICommandParameter, IParameterCollection
 
         Parameters = parameters;
 
-        Attributes = attributes.ToArray();
+        Attributes = [.. attributes];
 
         ExposedType = parameterInfo.ParameterType;
 

--- a/src/Commands/Core/Execution/ArgumentDictionary.cs
+++ b/src/Commands/Core/Execution/ArgumentDictionary.cs
@@ -15,14 +15,12 @@ public struct ArgumentDictionary
     const string U002D = "-";
 #endif
 
-    private int _remainingLength;
     private int _index = 0;
 
     private readonly List<string> _unnamedArgs;
     private readonly Dictionary<string, object?> _namedArgs;
 
-    internal readonly int AvailableLength
-        => _remainingLength;
+    internal int AvailableLength { get; private set; }
 
     /// <summary>
     ///     Gets the number of arguments present in the set.
@@ -70,7 +68,7 @@ public struct ArgumentDictionary
         }
 
         _unnamedArgs = unnamedFill;
-        _remainingLength = _unnamedArgs.Count + _namedArgs.Count;
+        AvailableLength = _unnamedArgs.Count + _namedArgs.Count;
     }
 
     /// <summary>
@@ -80,7 +78,7 @@ public struct ArgumentDictionary
     {
         _namedArgs = null!;
         _unnamedArgs = null!;
-        _remainingLength = 0;
+        AvailableLength = 0;
     }
 
     #region Internals
@@ -136,7 +134,7 @@ public struct ArgumentDictionary
     internal void SetParseIndex(int index)
     {
         _index = index;
-        _remainingLength = AvailableLength - index;
+        AvailableLength -= index;
     }
 
     #endregion

--- a/src/Commands/Core/Execution/CommandOptions.cs
+++ b/src/Commands/Core/Execution/CommandOptions.cs
@@ -78,10 +78,7 @@ public sealed class CommandOptions
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class EmptyServiceProvider : IServiceProvider
     {
-        private static readonly EmptyServiceProvider _i = new();
-
-        internal static EmptyServiceProvider Instance
-            => _i;
+        internal static EmptyServiceProvider Instance { get; } = new();
 
         /// <inheritdoc />
         public object? GetService(Type serviceType)

--- a/src/Commands/Core/Results/ResultHandler.cs
+++ b/src/Commands/Core/Results/ResultHandler.cs
@@ -187,7 +187,7 @@ public abstract class ResultHandler
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Task<>))]
     [UnconditionalSuppressMessage("AotAnalysis", "IL2075", Justification = "The availability of Task<> is ensured at compile-time.")]
 #endif
-    protected async virtual ValueTask HandleMethodReturn(ICallerContext caller, IResult result, IServiceProvider services, CancellationToken cancellationToken)
+    protected virtual async ValueTask HandleMethodReturn(ICallerContext caller, IResult result, IServiceProvider services, CancellationToken cancellationToken)
     {
         async ValueTask Respond(object? obj)
         {

--- a/src/Commands/Parsing/Parsers/TimeSpanParser.cs
+++ b/src/Commands/Parsing/Parsers/TimeSpanParser.cs
@@ -4,7 +4,7 @@ namespace Commands.Parsing;
 
 internal sealed partial class TimeSpanParser : TypeParser<TimeSpan>
 {
-    private static readonly IReadOnlyDictionary<string, Func<string, TimeSpan>> _callback;
+    private static readonly Dictionary<string, Func<string, TimeSpan>> _callback;
 
     private static readonly Regex _regex = new(@"(\d*)\s*([a-zA-Z]*)\s*(?:and|,)?\s*", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -68,8 +68,8 @@ internal sealed partial class TimeSpanParser : TypeParser<TimeSpan>
         => new(int.Parse(match), 0, 0, 0);
 
     private static TimeSpan Weeks(string match)
-        => new((int.Parse(match) * 7), 0, 0, 0);
+        => new(int.Parse(match) * 7, 0, 0, 0);
 
     private static TimeSpan Months(string match)
-        => new(((int)(int.Parse(match) * 30.437)), 0, 0, 0);
+        => new((int)(int.Parse(match) * 30.437), 0, 0, 0);
 }

--- a/src/Commands/Testing/Execution/TestRunner.cs
+++ b/src/Commands/Testing/Execution/TestRunner.cs
@@ -58,7 +58,7 @@ public sealed class TestRunner
     ///     Gets a collection of properties to configure a new instance of <see cref="TestRunner"/>.
     /// </summary>
     public static TestRunnerProperties With { get; } = new();
-    
+
     /// <summary>
     ///     Defines a collection of properties to configure and convert into a new instance of <see cref="TestRunner"/>, with the specified commands.
     /// </summary>

--- a/src/Commands/_globals.cs
+++ b/src/Commands/_globals.cs
@@ -5,6 +5,9 @@
 global using System.Collections;
 
 global using System.Diagnostics;
+
+#if NET8_0_OR_GREATER
 global using System.Diagnostics.CodeAnalysis;
+#endif
 
 global using System.Reflection;


### PR DESCRIPTION
- Standardization of `.ToArray()` to collection expressions where possible.
- Removal of unnecessary usings
- Adjustment of usings to be .NET-Version appropriate
- Performance improvement in `TimeSpanParser.cs`
- Removal of unnecessary generic use